### PR TITLE
Set the canvas's display mode to inline-block

### DIFF
--- a/style/main.css
+++ b/style/main.css
@@ -6,6 +6,7 @@ body {
 
 #canvas {
   border: 1px solid #CCC;
+  display: inline-block;
 }
 
 #time_stats {


### PR DESCRIPTION
In Firefox, inline images with an invalid or empty src are collapsed, like an empty text element, so the canvas almost disappears (it's 2x22 pixels for me). Setting the display mode to inline-block forces it to keep its specified width/height even when empty.
